### PR TITLE
ci: add basic GitHub Actions workflow (fmt, clippy, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace --all-features --no-fail-fast


### PR DESCRIPTION
## Summary

Adds the smallest CI surface the project has been running locally:

| Job   | Command |
|-------|---------|
| fmt   | \`cargo fmt --all --check\` |
| clippy | \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` |
| test  | \`cargo test --workspace --all-features --no-fail-fast\` |

Triggers on push to \`main\` and on every pull request. Uses
\`dtolnay/rust-toolchain@stable\` for the toolchain and
\`Swatinem/rust-cache@v2\` for cargo caching. \`RUSTFLAGS=-D warnings\` is
set at job-env level so any warning fails the build, matching the
local posture the project has been running.

## Verification

Run locally on \`main\` from this branch:

- \`cargo fmt --all --check\` — clean
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- \`cargo test --workspace --all-features --no-fail-fast\` — 158 pass

The same commands have been run locally against the open audit-related
PRs (#5, #6, #7); each of those PRs has the workflow added to its
branch as well so CI runs without requiring a rebase before review.
PR #6 needed a small \`cargo fmt\` pass + removal of an unused
\`HashMap\` import (now-unused after the \`Swarm::run\` signature
migration); those fixes were folded into PR #6 itself.

## Out of scope

- Multi-OS / multi-toolchain matrix
- \`cargo doc\` check
- Coverage upload
- Release / publish automation

Easy to extend later — this PR's purpose is to establish the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)